### PR TITLE
Removed references to MAX_SAFE_INT and MIN_SAFE_INT

### DIFF
--- a/fake.js
+++ b/fake.js
@@ -271,13 +271,16 @@ var _getRandomNumber = function (min, max, isInteger) {
   return r;
 };
 
+var MAX_INT = 9007199254740991;
+var MIN_INT = -9007199254740991;
+
 Fake.simpleSchemaDoc = function(schema) {
   var fakeObj = {};
   _.each(schema._schemaKeys, function (key) {
     var schemaKey = schema._schema[key],
         type = schema._schema[key].type.name,
-        max = _.get(schemaKey, 'max', Number.MAX_SAFE_INTEGER),
-        min = _.get(schemaKey, 'min', Number.MIN_SAFE_INTEGER),
+        max = _.get(schemaKey, 'max', Number.MAX_INT),
+        min = _.get(schemaKey, 'min', Number.MIN_INT),
         allowedValues = _.get(schemaKey, 'allowedValues', undefined),
         value = null;
     min = _.clamp(min, Number.MIN_SAFE_INTEGER, max);

--- a/fake.js
+++ b/fake.js
@@ -279,8 +279,8 @@ Fake.simpleSchemaDoc = function(schema) {
   _.each(schema._schemaKeys, function (key) {
     var schemaKey = schema._schema[key],
         type = schema._schema[key].type.name,
-        max = _.get(schemaKey, 'max', Number.MAX_INT),
-        min = _.get(schemaKey, 'min', Number.MIN_INT),
+        max = _.get(schemaKey, 'max', MAX_INT),
+        min = _.get(schemaKey, 'min', MIN_INT),
         allowedValues = _.get(schemaKey, 'allowedValues', undefined),
         value = null;
     min = _.clamp(min, Number.MIN_SAFE_INTEGER, max);

--- a/fake.js
+++ b/fake.js
@@ -283,7 +283,7 @@ Fake.simpleSchemaDoc = function(schema) {
         min = _.get(schemaKey, 'min', MIN_INT),
         allowedValues = _.get(schemaKey, 'allowedValues', undefined),
         value = null;
-    min = _.clamp(min, Number.MIN_SAFE_INTEGER, max);
+    min = _.clamp(min, MIN_INT, max);
     switch(type) {
       case 'String':
         if (allowedValues) {

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name:     "muqube:fake",
-  version:  "0.4.3_4",
+  version:  "0.4.3_5",
   summary:  "Random text, data and simple schema docs generator",
   git:      "https://github.com/muqube/meteor-fake",
   documentation: "README.md"

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name:     "muqube:fake",
-  version:  "0.4.3_5",
+  version:  "0.4.3_6",
   summary:  "Random text, data and simple schema docs generator",
   git:      "https://github.com/muqube/meteor-fake",
   documentation: "README.md"

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name:     "muqube:fake",
-  version:  "0.4.3_3",
+  version:  "0.4.3_4",
   summary:  "Random text, data and simple schema docs generator",
   git:      "https://github.com/muqube/meteor-fake",
   documentation: "README.md"


### PR DESCRIPTION
Number.MAX_SAFE_INT and Number.MIN_SAFE_INT were undefined in the meteor server side. References to these special values were removed to make simpleSchema document generation on server.